### PR TITLE
Feature to enable cropping to the screenRect

### DIFF
--- a/src/ofxScrollView.cpp
+++ b/src/ofxScrollView.cpp
@@ -677,7 +677,20 @@ ofMatrix4x4 ofxScrollView::getMatrixForRect(const ofRectangle & rect) {
     float rectScale = rect.width / contentRect.width;
     
     ofMatrix4x4 rectMat;
-    rectMat.preMultTranslate(ofVec3f(rect.x, rect.y, 0.0));
+    if (cropToWindowRect)
+    {
+        /*
+         * Because when we are cropping, we are always drawing
+         * relative to 0, 0, we need remove the offset effect
+         * of the window rect.
+         */
+        rectMat.preMultTranslate(ofVec3f(rect.x - windowRect.x, rect.y - windowRect.y, 0.0));
+    }
+    else
+    {
+        rectMat.preMultTranslate(ofVec3f(rect.x, rect.y, 0.0));
+    }
+
     rectMat.preMultScale(ofVec3f(rectScale, rectScale, 1.0));
     
     return rectMat;

--- a/src/ofxScrollView.cpp
+++ b/src/ofxScrollView.cpp
@@ -169,6 +169,8 @@ void ofxScrollView::reset() {
     
     scrollRect.width = scrollRectEased.width = contentRect.width * scale;
     scrollRect.height = scrollRectEased.height = contentRect.height * scale;
+    scrollRect.x = windowRect.x;
+    scrollRect.y = windowRect.y;
     scrollRect = scrollRectEased = getRectContainedInWindowRect(scrollRect);
     
     mat = getMatrixForRect(scrollRect);

--- a/src/ofxScrollView.cpp
+++ b/src/ofxScrollView.cpp
@@ -43,6 +43,8 @@ ofxScrollView::ofxScrollView() {
     scaleMin = 1.0;
     scaleMax = 1.0;
     
+    cropToWindowRect = false;
+
     setUserInteraction(true);
     setPinchZoom(true);
     setDoubleTapZoom(true);
@@ -205,6 +207,32 @@ void ofxScrollView::fitContentToWindow(ofAspectRatioMode aspectRatioMode) {
     scaleMin = MIN(scaleMin, 1.0);
     scaleMax = 1.0;
     scale = scaleMin;
+}
+
+//--------------------------------------------------------------
+bool ofxScrollView::getCropToWindowRect() {
+    return cropToWindowRect;
+}
+
+void ofxScrollView::setCropToWindowRect(bool bCrop) {
+    cropToWindowRect = bCrop;
+
+    if (bCrop)
+    {
+        /*
+         * Make sure our frame buffer is allocated and
+         * as large as our window rectangle.
+         */
+        frameBuffer.allocate(static_cast<int>(windowRect.width), static_cast<int>(windowRect.height));
+    }
+    else
+    {
+        /*
+         * We can destroy the frame buffer as we no
+         * longer need it.
+         */
+        frameBuffer.clear();
+    }
 }
 
 //--------------------------------------------------------------
@@ -674,12 +702,31 @@ ofVec2f ofxScrollView::getScreenPointAtContentPoint(const ofRectangle & rect,
 
 //--------------------------------------------------------------
 void ofxScrollView::begin() {
+    if (cropToWindowRect)
+    {
+        ofColor bg = ofGetBackgroundColor();
+        frameBuffer.begin();
+        ofClear(bg);
+    }
+
     ofPushMatrix();
     ofMultMatrix(mat);
+
 }
 
 void ofxScrollView::end() {
     ofPopMatrix();
+
+    if (cropToWindowRect)
+    {
+        frameBuffer.end();
+
+        /*
+         * Now, let's draw the relevant part of the
+         * frame buffer.
+         */
+        frameBuffer.draw(windowRect);
+     }
 }
 
 void ofxScrollView::draw() {

--- a/src/ofxScrollView.cpp
+++ b/src/ofxScrollView.cpp
@@ -43,6 +43,8 @@ ofxScrollView::ofxScrollView() {
     scaleMin = 1.0;
     scaleMax = 1.0;
     
+    cropToWindowRect = false;
+
     setUserInteraction(true);
     setPinchZoom(true);
     setDoubleTapZoom(true);
@@ -207,6 +209,32 @@ void ofxScrollView::fitContentToWindow(ofAspectRatioMode aspectRatioMode) {
     scaleMin = MIN(scaleMin, 1.0);
     scaleMax = 1.0;
     scale = scaleMin;
+}
+
+//--------------------------------------------------------------
+bool ofxScrollView::getCropToWindowRect() {
+    return cropToWindowRect;
+}
+
+void ofxScrollView::setCropToWindowRect(bool bCrop) {
+    cropToWindowRect = bCrop;
+
+    if (bCrop)
+    {
+        /*
+         * Make sure our frame buffer is allocated and
+         * as large as our window rectangle.
+         */
+        frameBuffer.allocate(static_cast<int>(windowRect.width), static_cast<int>(windowRect.height));
+    }
+    else
+    {
+        /*
+         * We can destroy the frame buffer as we no
+         * longer need it.
+         */
+        frameBuffer.clear();
+    }
 }
 
 //--------------------------------------------------------------
@@ -676,12 +704,31 @@ ofVec2f ofxScrollView::getScreenPointAtContentPoint(const ofRectangle & rect,
 
 //--------------------------------------------------------------
 void ofxScrollView::begin() {
+    if (cropToWindowRect)
+    {
+        ofColor bg = ofGetBackgroundColor();
+        frameBuffer.begin();
+        ofClear(bg);
+    }
+
     ofPushMatrix();
     ofMultMatrix(mat);
+
 }
 
 void ofxScrollView::end() {
     ofPopMatrix();
+
+    if (cropToWindowRect)
+    {
+        frameBuffer.end();
+
+        /*
+         * Now, let's draw the relevant part of the
+         * frame buffer.
+         */
+        frameBuffer.draw(windowRect);
+     }
 }
 
 void ofxScrollView::draw() {

--- a/src/ofxScrollView.h
+++ b/src/ofxScrollView.h
@@ -64,6 +64,19 @@ public:
      */
     void fitContentToWindow(ofAspectRatioMode aspectRatioMode);
 
+    /**
+     * @brief getCropToWindowRect() - Returns true if we crop drawing to the Window Rect
+     * @return bool - true if we are cropping, false if we draw outside the Window Rect
+     */
+    bool getCropToWindowRect();
+
+    /**
+     * @brief setCropToWindowRect() - Sets the crop value.  True if we crop to the Window Rect, false to draw outside it.
+     * @param bCrop
+     *
+     * The initial setting of this is false, to be compatible with previous behaviour.
+     */
+    void setCropToWindowRect(bool bCrop);
 
     void setScale(float value);
     void setScaleMin(float value);
@@ -195,6 +208,9 @@ public:
     float scaleMax;
     ofMatrix4x4 mat;
     
+    bool cropToWindowRect;
+    ofFbo frameBuffer;
+
     vector<ofxScrollViewTouchPoint> touchPoints;
     ofxScrollViewTouchPoint touchDownPointLast;
     

--- a/src/ofxScrollView.h
+++ b/src/ofxScrollView.h
@@ -46,8 +46,24 @@ public:
     
     void setWindowRect(const ofRectangle & rect);
     void setContentRect(const ofRectangle & rect);
-    
+
+
+    /**
+     * @brief fitContentToWindow() - Scale the content area to fit the window area.
+     * @param aspectRatioMode
+     *
+     * The value of aspectRatioMode may be one of:
+     *
+     *   OF_ASPECT_RATIO_KEEP - Window rect completely contains all of content rect.
+     *                           Content is centered within thei window rect.
+     *
+     *   OF_ASPECT_RATIO_KEEP_BY_EXPANDING - Window rect is filled in one direction only.
+     *                                       Content may overflow window rect.
+     *
+     *   OF_ASPECT_RATIO_IGNORE - Has no effect.  This is the default mode.
+     */
     void fitContentToWindow(ofAspectRatioMode aspectRatioMode);
+
 
     void setScale(float value);
     void setScaleMin(float value);

--- a/src/ofxScrollView.h
+++ b/src/ofxScrollView.h
@@ -49,6 +49,20 @@ public:
     
     void fitContentToWindow(ofAspectRatioMode aspectRatioMode);
 
+    /**
+     * @brief getCropToWindowRect() - Returns true if we crop drawing to the Window Rect
+     * @return bool - true if we are cropping, false if we draw outside the Window Rect
+     */
+    bool getCropToWindowRect();
+
+    /**
+     * @brief setCropToWindowRect() - Sets the crop value.  True if we crop to the Window Rect, false to draw outside it.
+     * @param bCrop
+     *
+     * The initial setting of this is false, to be compatible with previous behaviour.
+     */
+    void setCropToWindowRect(bool bCrop);
+
     void setScale(float value);
     void setScaleMin(float value);
     void setScaleMax(float value);
@@ -179,6 +193,9 @@ public:
     float scaleMax;
     ofMatrix4x4 mat;
     
+    bool cropToWindowRect;
+    ofFbo frameBuffer;
+
     vector<ofxScrollViewTouchPoint> touchPoints;
     ofxScrollViewTouchPoint touchDownPointLast;
     


### PR DESCRIPTION
I apologise, but this feature depends on the previous pull request:  https://github.com/julapy/ofxScrollView/pull/2

Created functions:  
- setCropToWindowRect()
- getCropToWindowRect()

The feature defaults to false to maintain backwards compatibility.  When true, instead of drawing the scroll outside the screen rectangle, it constrains drawing to only occupy the screen rectangle.